### PR TITLE
Fix highlight setting in config.toml

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,9 +2,11 @@ base_url = "https://oceanic-zen.netlify.app/"
 title = "Blog name"
 description = "Personal blog"
 compile_sass = true
+build_search_index = false
+
+[markdown]
 highlight_code = true
 highlight_theme = "visual-studio-dark"
-build_search_index = false
 
 [extra]
 author = "Barlog M."


### PR DESCRIPTION
The highlight settings need to be in the `[markdown]` section.

https://www.getzola.org/documentation/getting-started/configuration/