### PR TITLE
Don't justify body text

### DIFF
--- a/sass/theme.scss
+++ b/sass/theme.scss
@@ -59,10 +59,6 @@ main {
     grid-area: main;
 }
 
-p {
-    text-align: justify;
-}
-
 footer {
     color: $gray_light;
     padding: 0 $padding $padding $padding;


### PR DESCRIPTION
I stumbled upon a website with this theme and found the justification distracting.

It's a design decision in a way, but I consider it unnecessarily making the content harder to read.

https://designforhackers.com/blog/justify-text-html-css/
https://uxmovement.com/content/6-surprising-bad-practices-that-hurt-dyslexic-users/
https://ruitina.com/dont-justify-text-on-websites-and-apps/